### PR TITLE
fix: issue with exact duplicates not being returned

### DIFF
--- a/semhash/index.py
+++ b/semhash/index.py
@@ -25,10 +25,6 @@ class Index:
         self.backend = backend
         self.vectors = vectors
 
-    def items_as_sequence(self) -> list[dict[str, str]]:
-        """Return all items as a single sequence."""
-        return [item[0] for item in self.items]
-
     @classmethod
     def from_vectors_and_items(cls, vectors: np.ndarray, items: list[DictItem], backend_type: Backend) -> Index:
         """

--- a/semhash/records.py
+++ b/semhash/records.py
@@ -39,3 +39,8 @@ def map_deduplication_result_to_strings(result: DeduplicationResult, columns: Se
             )
         )
     return DeduplicationResult(deduplicated=deduplicated_str, duplicates=mapped, threshold=result.threshold)
+
+
+def add_scores_to_records(records: list[dict[str, str]]) -> list[tuple[dict[str, str], float]]:
+    """Add scores to records and return a DeduplicationResult."""
+    return [(record, 1.0) for record in records]

--- a/semhash/utils.py
+++ b/semhash/utils.py
@@ -18,4 +18,4 @@ class Encoder(Protocol):
         :param **kwargs: Additional keyword arguments.
         :return: The embeddings of the sentences.
         """
-        ...
+        ...  # pragma: no cover

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "semhash"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "frozendict" },
@@ -1313,7 +1313,7 @@ name = "tqdm"
 version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
 wheels = [


### PR DESCRIPTION
Closes #34 

This PR solves an issue where exact duplicates had empty `duplicates` fields. This was an oversight.