### PR TITLE
Fix wrong bibtex citation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,9 @@ MIT
 If you use SemHash in your research, please cite the following:
 ```bibtex
 @software{minishlab2025semhash,
-  authors = {Thomas van Dongen, Stephan Tulkens},
+  author = {Thomas van Dongen and Stephan Tulkens},
   title = {SemHash: Fast Semantic Text Deduplication},
   year = {2025},
-  url = {https://github.com/MinishLab/semhash},
+  url = {https://github.com/MinishLab/semhash}
 }
 ```


### PR DESCRIPTION
@Pringled I was trying to cite this work in my article, and the bibtex code provided in the README is wrong. The `authors` key is not valid in bibtex.

I've pushed a fix to  change it to`author`, and it's parsed correctly now.

**Before:**
![image](https://github.com/user-attachments/assets/03ead1da-bca5-41c3-b8f6-86c849fa0bf5)

**After:**
![image](https://github.com/user-attachments/assets/a85855f0-701c-4ba1-9e65-e36460f66395)


