### PR TITLE
feat: Added selected_with_duplicates functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ least_similar = deduplication_result.get_least_similar_from_duplicates()
 
 # Rethreshold the duplicates. This allows you to instantly rethreshold the duplicates with a new threshold without having to re-deduplicate the texts.
 deduplication_result.rethreshold(0.95)
+
+# View selected records along with their duplicates.
+# This is the opposite of the `filtered` attribute, which shows for every duplicate the record that caused it.
+deduplication_result.selected_with_duplicates
 ```
 
 </details>

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Generic, Hashable, Sequence, TypeVar
+from typing import Any, Generic, Hashable, Optional, Sequence, TypeVar
 
 from frozendict import frozendict
 from typing_extensions import TypeAlias
@@ -69,7 +69,7 @@ class DeduplicationResult(Generic[Record]):
     selected: list[Record] = field(default_factory=list)
     filtered: list[DuplicateRecord] = field(default_factory=list)
     threshold: float = field(default=0.9)
-    columns: Sequence[str] | None = field(default=None)
+    columns: Optional[Sequence[str]] = field(default=None)
     deduplicated: list[Record] = field(default_factory=list)  # Deprecated
     duplicates: list[DuplicateRecord] = field(default_factory=list)  # Deprecated
 

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -1,9 +1,10 @@
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Generic, Hashable, Sequence, TypeAlias, TypeVar
+from typing import Any, Generic, Hashable, Sequence, TypeVar
 
 from frozendict import frozendict
+from typing_extensions import TypeAlias
 
 from semhash.utils import to_frozendict
 

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Generic, Hashable, TypeVar
 
+from semhash.utils import to_frozendict
+
 Record = TypeVar("Record", str, dict[str, Any])
 
 
@@ -115,7 +117,12 @@ class DeduplicationResult(Generic[Record]):
         def _to_hashable(record: Record) -> Hashable:
             """Convert a record to a hashable representation."""
             if isinstance(record, dict):
-                return tuple(sorted(record.items()))
+                # Coerce non-hashable values to str so the frozendict is hashable
+                strified = {k: (v if isinstance(v, str) else str(v)) for k, v in record.items()}
+                # Return a frozendict for immutability and hashability
+                return to_frozendict(strified, set(record.keys()))
+
+            # Strings are already hashable
             return record
 
         # Build a mapping from original-record  to  [(duplicate, score), …]

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -40,6 +40,7 @@ class DeduplicationResult(Generic[Record]):
         selected: List of deduplicated records after removing duplicates.
         filtered: List of DuplicateRecord objects containing details about duplicates of an original record.
         threshold: The similarity threshold used for deduplication.
+        columns: Columns used for deduplication.
         deduplicated: Deprecated, use selected instead.
         duplicates: Deprecated, use filtered instead.
 

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -128,8 +128,15 @@ class DeduplicationResult(Generic[Record]):
             for original_record, score in duplicate_record.duplicates:
                 buckets[_to_hashable(original_record)].append((duplicate_record.record, float(score)))
 
-        # Assemble the final list in the same order as self.selected
-        return [(rec, buckets.get(_to_hashable(rec), [])) for rec in self.selected]
+        result: list[tuple[Record, list[tuple[Record, float]]]] = []
+        for selected in self.selected:
+            # Get the list of duplicates for the selected record
+            raw_list = buckets.get(_to_hashable(selected), [])
+            # Ensure we don't have duplicates in the list
+            deduped = {_to_hashable(rec): (rec, score) for rec, score in raw_list}
+            result.append((selected, list(deduped.values())))
+
+        return result
 
 
 @dataclass

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Generic, Hashable, Optional, Sequence, TypeVar
+from typing import Any, Generic, Hashable, Sequence, TypeVar
 
 from frozendict import frozendict
 from typing_extensions import TypeAlias
@@ -69,7 +71,7 @@ class DeduplicationResult(Generic[Record]):
     selected: list[Record] = field(default_factory=list)
     filtered: list[DuplicateRecord] = field(default_factory=list)
     threshold: float = field(default=0.9)
-    columns: Optional[Sequence[str]] = field(default=None)
+    columns: Sequence[str] | None = field(default=None)
     deduplicated: list[Record] = field(default_factory=list)  # Deprecated
     duplicates: list[DuplicateRecord] = field(default_factory=list)  # Deprecated
 

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -117,10 +117,10 @@ class DeduplicationResult(Generic[Record]):
         def _to_hashable(record: Record) -> Hashable:
             """Convert a record to a hashable representation."""
             if isinstance(record, dict):
-                # Coerce non-hashable values to str so the frozendict is hashable
-                strified = {k: (v if isinstance(v, str) else str(v)) for k, v in record.items()}
+                # Convert non-hashable values to str so the frozendict is hashable
+                converted = {k: (v if isinstance(v, str) else str(v)) for k, v in record.items()}
                 # Return a frozendict for immutability and hashability
-                return to_frozendict(strified, set(record.keys()))
+                return to_frozendict(converted, set(record.keys()))
 
             # Strings are already hashable
             return record

--- a/semhash/datamodels.py
+++ b/semhash/datamodels.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Generic, Hashable, TypeVar
+from typing import Any, Generic, Hashable, Sequence, TypeVar
 
 from semhash.utils import to_frozendict
 
@@ -48,6 +48,7 @@ class DeduplicationResult(Generic[Record]):
     selected: list[Record] = field(default_factory=list)
     filtered: list[DuplicateRecord] = field(default_factory=list)
     threshold: float = field(default=0.9)
+    columns: Sequence[str] = field(default_factory=list)
     deduplicated: list[Record] = field(default_factory=list)  # Deprecated
     duplicates: list[DuplicateRecord] = field(default_factory=list)  # Deprecated
 
@@ -115,14 +116,9 @@ class DeduplicationResult(Generic[Record]):
         """
 
         def _to_hashable(record: Record) -> Hashable:
-            """Convert a record to a hashable representation."""
             if isinstance(record, dict):
-                # Convert non-hashable values to str so the frozendict is hashable
-                converted = {k: (v if isinstance(v, str) else str(v)) for k, v in record.items()}
-                # Return a frozendict for immutability and hashability
-                return to_frozendict(converted, set(record.keys()))
-
-            # Strings are already hashable
+                # Convert dict to frozendict for immutability and hashability
+                return to_frozendict(record, set(self.columns))
             return record
 
         # Build a mapping from original-record  to  [(duplicate, score), …]

--- a/semhash/records.py
+++ b/semhash/records.py
@@ -1,13 +1,6 @@
 from typing import Sequence
 
-from frozendict import frozendict
-
 from semhash.datamodels import DeduplicationResult, DuplicateRecord
-
-
-def to_frozendict(record: dict[str, str], columns: set[str]) -> frozendict[str, str]:
-    """Convert a record to a frozendict."""
-    return frozendict({k: record.get(k, "") for k in columns})
 
 
 def dict_to_string(record: dict[str, str], columns: Sequence[str]) -> str:

--- a/semhash/semhash.py
+++ b/semhash/semhash.py
@@ -190,7 +190,9 @@ class SemHash(Generic[Record]):
 
         # If no records are left after removing exact duplicates, return early
         if not dict_records:
-            return DeduplicationResult(deduplicated=[], duplicates=duplicate_records, threshold=threshold)
+            return DeduplicationResult(
+                deduplicated=[], duplicates=duplicate_records, threshold=threshold, columns=self.columns
+            )
 
         # Compute embeddings for the new records
         embeddings = self._featurize(records=dict_records, columns=self.columns, model=self.model)
@@ -212,7 +214,7 @@ class SemHash(Generic[Record]):
                 )
 
         result = DeduplicationResult(
-            deduplicated=deduplicated_records, duplicates=duplicate_records, threshold=threshold
+            deduplicated=deduplicated_records, duplicates=duplicate_records, threshold=threshold, columns=self.columns
         )
 
         if self._was_string:
@@ -281,7 +283,7 @@ class SemHash(Generic[Record]):
             seen_items.update(frozen_items)
 
         result = DeduplicationResult(
-            deduplicated=deduplicated_records, duplicates=duplicate_records, threshold=threshold
+            deduplicated=deduplicated_records, duplicates=duplicate_records, threshold=threshold, columns=self.columns
         )
 
         if self._was_string:

--- a/semhash/semhash.py
+++ b/semhash/semhash.py
@@ -11,8 +11,8 @@ from vicinity import Backend
 
 from semhash.datamodels import DeduplicationResult, DuplicateRecord, FilterResult, Record
 from semhash.index import Index
-from semhash.records import add_scores_to_records, map_deduplication_result_to_strings, to_frozendict
-from semhash.utils import Encoder, compute_candidate_limit
+from semhash.records import add_scores_to_records, map_deduplication_result_to_strings
+from semhash.utils import Encoder, compute_candidate_limit, to_frozendict
 
 
 class SemHash(Generic[Record]):

--- a/semhash/utils.py
+++ b/semhash/utils.py
@@ -1,6 +1,7 @@
 from typing import Any, Protocol, Sequence, Union
 
 import numpy as np
+from frozendict import frozendict
 
 
 class Encoder(Protocol):
@@ -19,6 +20,11 @@ class Encoder(Protocol):
         :return: The embeddings of the sentences.
         """
         ...  # pragma: no cover
+
+
+def to_frozendict(record: dict[str, str], columns: set[str]) -> frozendict[str, str]:
+    """Convert a record to a frozendict."""
+    return frozendict({k: record.get(k, "") for k in columns})
 
 
 def compute_candidate_limit(

--- a/tests/test_datamodels.py
+++ b/tests/test_datamodels.py
@@ -150,3 +150,18 @@ def test_selected_with_duplicates_dicts() -> None:
     kept, dups = pairs[0]
     assert kept == selected
     assert {r["id"] for r, _ in dups} == {1, 2}
+
+
+def test_selected_with_duplicates_unhashable_values() -> None:
+    """Test selected_with_duplicates with unhashable values in records."""
+    selected = {"a": [1, 2, 3]}  # list -> unhashable value
+    filtered = {"a": [1, 2, 3], "flag": True}
+
+    d = DeduplicationResult(
+        selected=[selected],
+        filtered=[DuplicateRecord(filtered, exact=False, duplicates=[(selected, 1.0)])],
+        threshold=0.8,
+    )
+
+    pairs = d.selected_with_duplicates
+    assert pairs == [(selected, [(filtered, 1.0)])]


### PR DESCRIPTION
This PR adds a `selected_with_duplicates` property that can be used to easily see which duplicates were removed for a selected record. Example usage:
```python
from semhash import SemHash

data = [
    {"id": 0, "text": "hello"},
    {"id": 1, "text": "hello"},
    {"id": 2, "text": "helllo"},
]

semhash = SemHash.from_records(records=data, columns=['text'])
deduplication_result = semhash.self_deduplicate(threshold=0.1)
print(deduplication_result.selected_with_duplicates)
```

Which gives you 
`[({'id': 0, 'text': 'hello'}, [({'id': 1, 'text': 'hello'}, 1.0), ({'id': 2, 'text': 'helllo'}, 0.10063767433166504)])]`

It's also fast: on ag_news for example it runs in 0.07 seconds.